### PR TITLE
Added optional `mpv_args` argument to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -632,7 +632,7 @@ export default class NodeMpv implements EventEmitter {
 	/**
 	 * Starts mpv, by spawning a child process or by attaching to existing socket
 	 */
-	start(): Promise<void>;
+	start(mpv_args?: Array<string|number>): Promise<void>;
 	/**
 	 * Closes mpv
 	 *


### PR DESCRIPTION
Fixes an issue where typescript will complain about providing the mpv_args argument on the Node_MPV.start() method